### PR TITLE
List IDs for items with hover images

### DIFF
--- a/improvecsv.py
+++ b/improvecsv.py
@@ -168,7 +168,15 @@ if 'secondary_hover_image_link' in df.columns:
         group_mask = df[group_col].astype(str).str.strip().isin(['1', 'True', 'true'])
         hover_mask &= group_mask
 
-    hover_count = int(hover_mask.sum())
-    print(f"\n{hover_count} Artikel mit Hover Bilder")
+    if 'id' in df.columns:
+        hover_ids = df.loc[hover_mask, 'id'].dropna().astype(str).unique().tolist()
+    else:
+        hover_ids = df.index[hover_mask].astype(str).tolist()
+
+    hover_count = len(hover_ids)
+    if hover_count:
+        print(f"\n{hover_count} Artikel mit Hover Bilder: {', '.join(hover_ids)}")
+    else:
+        print("\nKeine Artikel mit Hover Bilder.")
 else:
     print("\nℹ️ Keine 'secondary_hover_image_link'-Spalte gefunden – Hover-Bildprüfung nicht möglich.")


### PR DESCRIPTION
## Summary
- Show IDs for products that include secondary hover images and print them alongside the total count.

## Testing
- `pip install pandas`
- `python -m py_compile improvecsv.py`
- `python improvecsv.py <<'EOF'
/workspace/Plenty-Doofinder-Python-CSS-Transcoder-Script/test_input.csv
EOF`

------
https://chatgpt.com/codex/tasks/task_e_689c6c01bd448331b83a4cf2fde95c2e