### PR TITLE
Add kopfform extraction from title

### DIFF
--- a/improvecsv.py
+++ b/improvecsv.py
@@ -124,6 +124,18 @@ if 'title' in df.columns:
     df.loc[titles.str.contains('gelb verzinkt', case=False, na=False), 'material'] = 'Stahl gelb verzinkt'
     df.loc[(df['material'] == '') & titles.str.contains('verzinkt', case=False, na=False), 'material'] = 'Stahl verzinkt'
 
+# --- Kopfform aus Titel ableiten ---
+df['kopfform'] = ''
+if 'title' in df.columns:
+    titles = df['title'].astype(str)
+    df.loc[titles.str.contains('Tellerkopf', case=False, na=False), 'kopfform'] = 'Tellerkopf'
+    df.loc[titles.str.contains('Senkkopf', case=False, na=False), 'kopfform'] = 'Senkkopf'
+    df.loc[titles.str.contains('Linsenkopf', case=False, na=False), 'kopfform'] = 'Linsenkopf'
+    df.loc[titles.str.contains('Hammerkopf', case=False, na=False), 'kopfform'] = 'Hammerkopf'
+    df.loc[titles.str.contains('ohne Kopf', case=False, na=False), 'kopfform'] = 'ohne Kopf'
+    df.loc[titles.str.contains('Rundkopf', case=False, na=False), 'kopfform'] = 'Rundkopf'
+    df.loc[titles.str.contains('Zylinderkopf', case=False, na=False), 'kopfform'] = 'Zylinderkopf'
+
 # --- Output ---
 basename = os.path.basename(csv_pfad)
 basename_ohne_ext = os.path.splitext(basename)[0]


### PR DESCRIPTION
## Summary
- derive `kopfform` column from product titles, detecting various head types

## Testing
- `python -m py_compile improvecsv.py`


------
https://chatgpt.com/codex/tasks/task_e_68a332a64d8c83319906eb6d5db2d6b5