### PR TITLE
Improve category parsing and column alignment

### DIFF
--- a/improvecsv-n8n-workflow.js
+++ b/improvecsv-n8n-workflow.js
@@ -18,37 +18,152 @@ const CATEGORIES_TO_REMOVE = new Set([
   'ISEO','BEVER','EFF EFF','ABUS','INDEX',
 ].map(norm));
 
+// Try to parse string representations of lists (JSON or Python style)
+function parseListLike(raw) {
+  const queue = [String(raw)];
+  const attempts = [];
+  const seen = new Set();
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (typeof current !== 'string') continue;
+    const trimmed = current.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      if (!attempts.includes(trimmed)) attempts.push(trimmed);
+    }
+
+    // unwrap outer quotes and enqueue inner content for further processing
+    if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+      const inner = trimmed.slice(1, -1);
+      if (inner && !seen.has(inner)) queue.push(inner);
+    }
+
+    if (trimmed.includes('\\"')) queue.push(trimmed.replace(/\\"/g, '"'));
+    if (trimmed.includes("\\'")) queue.push(trimmed.replace(/\\'/g, "'"));
+  }
+
+  for (const attempt of attempts) {
+    try {
+      const parsed = JSON.parse(attempt);
+      if (Array.isArray(parsed)) return parsed;
+    } catch { /* try next approach */ }
+  }
+
+  for (const attempt of attempts) {
+    const parsed = parsePythonStyleStringList(attempt);
+    if (parsed) return parsed;
+  }
+
+  return null;
+}
+
+function parsePythonStyleStringList(str) {
+  const s = str.trim();
+  if (!s.startsWith('[') || !s.endsWith(']')) return null;
+
+  const result = [];
+  let i = 1;
+  const end = s.length - 1;
+
+  while (i < end) {
+    // Skip whitespace and commas between entries
+    while (i < end && /[\s,]/.test(s[i])) i++;
+    if (i >= end) break;
+
+    const quote = s[i];
+    if (quote !== '"' && quote !== "'") return null;
+    i++;
+
+    let value = '';
+    let closed = false;
+
+    while (i < end) {
+      const ch = s[i];
+
+      if (ch === '\\') {
+        if (i + 1 >= end) return null;
+        const esc = s[i + 1];
+        if (esc === 'u') {
+          const hex = s.slice(i + 2, i + 6);
+          if (hex.length < 4 || /[^0-9a-fA-F]/.test(hex)) return null;
+          value += String.fromCharCode(parseInt(hex, 16));
+          i += 6;
+          continue;
+        }
+
+        const escapes = { '\\': '\\', '"': '"', "'": "'", n: '\n', r: '\r', t: '\t' };
+        value += escapes.hasOwnProperty(esc) ? escapes[esc] : esc;
+        i += 2;
+        continue;
+      }
+
+      if (ch === quote) {
+        closed = true;
+        i++;
+        break;
+      }
+
+      value += ch;
+      i++;
+    }
+
+    if (!closed) return null;
+    result.push(value);
+
+    // skip trailing whitespace after element
+    while (i < end && /\s/.test(s[i])) i++;
+
+    if (i < end) {
+      if (s[i] === ',') {
+        i++;
+      } else {
+        return null;
+      }
+    }
+  }
+
+  return result;
+}
+
+function splitCategoryEntries(catStr) {
+  return catStr.split(/\s*%%\s*/).map(s => s.trim()).filter(Boolean);
+}
+
 // Parse '["Zubehör","Zubehör;Bits","Top Marken"]' to "Zubehör %% Zubehör > Bits"
 function parseCategoryCell(cell) {
   if (cell == null || String(cell).trim() === '') return '';
-  let v = String(cell).trim();
+  const raw = String(cell).trim();
 
-  // try JSON list first
-  if (v.startsWith('[') && v.endsWith(']')) {
-    try {
-      // handle doubled quotes from CSV
-      const fixed = v.replace(/\\"/g, '"').replace(/""/g, '"');
-      const arr = JSON.parse(fixed);
-      if (Array.isArray(arr)) {
-        const out = arr
-          .map(x => String(x).trim())
-          .filter(Boolean)
-          .map(entry => entry.includes(';')
-            ? entry.split(';').map(s => s.trim()).filter(Boolean).join(' > ')
-            : entry);
-        return out.join(' %% ');
-      }
-    } catch { /* fall through */ }
+  const parsedList = parseListLike(raw);
+  if (parsedList) {
+    const out = parsedList
+      .map(x => String(x).trim())
+      .filter(Boolean)
+      .map(entry => entry.includes(';')
+        ? entry.split(';').map(s => s.trim()).filter(Boolean).join(' > ')
+        : entry);
+    return out.join(' %% ');
   }
 
   // fallback: single string with semicolons
-  if (v.includes(';')) return v.split(';').map(s => s.trim()).filter(Boolean).join(' > ');
-  return v;
+  if (raw.includes(';')) {
+    return raw
+      .split(';')
+      .map(s => s.trim())
+      .filter(Boolean)
+      .join(' > ');
+  }
+
+  if (raw === '[]' || raw === '[""]' || raw === "['']") return '';
+  return raw;
 }
 
 function cleanDuplicateFlatCategories(catStr) {
   if (!catStr) return catStr;
-  const cats = catStr.split('%%').map(s => s.trim()).filter(Boolean);
+  const cats = splitCategoryEntries(catStr);
   const trees = cats.filter(c => c.includes('>'));
   const roots = new Set(trees.map(tr => tr.split('>')[0].trim()));
   return cats.filter(c => c.includes('>') || !roots.has(c)).join(' %% ');
@@ -57,7 +172,7 @@ function cleanDuplicateFlatCategories(catStr) {
 function removeBrandsFromCategory(catStr) {
   if (!catStr) return catStr;
   const keep = [];
-  for (const c of catStr.split('%%').map(s => s.trim()).filter(Boolean)) {
+  for (const c of splitCategoryEntries(catStr)) {
     const partsNorm = c.split('>').map(p => norm(p));
     if (partsNorm.some(p => CATEGORIES_TO_REMOVE.has(p))) continue;
     keep.push(c);
@@ -91,6 +206,7 @@ const out = items.map(it => {
   }
 
   // group_count
+  r.group_count = '';
   if (r.group_id !== undefined && r.group_id !== null && String(r.group_id).trim() !== '') {
     const n = groupCounts[r.group_id] || 1;
     r.group_count = n >= 2 ? `${n} Varianten` : '';
@@ -114,7 +230,7 @@ const out = items.map(it => {
   }
 
   // material from title
-  r.material = r.material || '';
+  r.material = '';
   const t = (r.title || '').toLowerCase();
   if (t.includes('edelstahl c1')) r.material = 'Edelstahl C1';
   else if (t.includes('edelstahl a2')) r.material = 'Edelstahl A2';
@@ -123,7 +239,7 @@ const out = items.map(it => {
   else if (!r.material && t.includes('verzinkt')) r.material = 'Stahl verzinkt';
 
   // kopfform from title
-  r.kopfform = r.kopfform || '';
+  r.kopfform = '';
   for (const h of HEADS) {
     if (new RegExp(h, 'i').test(r.title || '')) { r.kopfform = h; break; }
   }


### PR DESCRIPTION
## Summary
- add robust helpers to normalise category strings from JSON- and Python-style list literals before formatting
- reuse shared splitting when cleaning/removing categories and reset derived columns to mirror the Python script
- initialise group_count like the Python workflow to keep empty values consistent

## Testing
- `node - <<'NODE'
global.items = [
  { json: { category: '["","Zubeh\\u00f6r","Top Marken"]', brand: 'Top Marken', title: 'Schraube Edelstahl A2 Senkkopf', description: 'Mit ETA Zulassung', group_id: 'G1', group_leader: '1' } },
  { json: { category: '["Sonstiges"]', brand: 'Andere', title: 'Nagel verzinkt', description: 'Standard', group_id: 'G1', group_leader: '0' } },
  { json: { category: '["","Top Marken"]', brand: 'Top Marken', title: 'Zubehör Artikel', description: 'ohne', group_id: '', group_leader: 'false' } },
];
const result = require('./improvecsv-n8n-workflow.js');
console.log(JSON.stringify(result, null, 2));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d3e72142588331b29b6b6a329bb1b2